### PR TITLE
Diverse Source Files, Edit Translations

### DIFF
--- a/Classes/Mrimann/XliffTranslator/Controller/StandardController.php
+++ b/Classes/Mrimann/XliffTranslator/Controller/StandardController.php
@@ -23,15 +23,9 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 
 	/**
 	 * @Flow\Inject
-	 * @var \TYPO3\Flow\I18n\Service
+	 * @var \Mrimann\XliffTranslator\XliffTranslatorService
 	 */
-	protected $localizationService;
-
-	/**
-	 * @Flow\Inject
-	 * @var \TYPO3\Flow\I18n\Xliff\XliffParser
-	 */
-	protected $xliffParser;
+	protected $xliffTranslatorService;
 
 	/**
 	 * The index action that shows a list of packages that are available for testing
@@ -39,7 +33,7 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 	 * @return void
 	 */
 	public function indexAction() {
-		$this->view->assign('packages', $this->getAvailablePackages());
+		$this->view->assign('packages', $this->xliffTranslatorService->getAvailablePackages());
 	}
 
 	/**
@@ -58,73 +52,8 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 		// check if we're ready for the actual translation
 		if ($fromLang != '' && $toLang != '') {
 			$this->view->assign('readyForTranslating', TRUE);
-			$this->view->assign('translationMatrix', $this->generateTranslationMatrix($packageKey, $fromLang, $toLang));
+			$this->view->assign('translationMatrix', $this->xliffTranslatorService->generateTranslationMatrix($packageKey, $fromLang, $toLang));
 		}
-	}
-
-	/**
-	 * Generates a multi-dimensional array, the matrix, containing all translations units from the
-	 * source language, combined with (where existing) the translated snippets in the target
-	 * language.
-	 *
-	 * For each translation unit, the status is stated in the matrix (new and untranslated, modified
-	 * or already translated)
-	 *
-	 * @param string the package key
-	 * @param string the source language's language key
-	 * @param string the target language's language key
-	 * @return array the translation matrix
-	 */
-	protected function generateTranslationMatrix($packageKey, $fromLang, $toLang) {
-		$fromLocale = new \TYPO3\Flow\I18n\Locale($fromLang);
-		$fromItems = $this->getXliffDataAsArray($packageKey, 'Main', $fromLocale);
-
-		$toLocale = new \TYPO3\Flow\I18n\Locale($toLang);
-		$toItems = $this->getXliffDataAsArray($packageKey, 'Main', $toLocale);
-
-		foreach ($fromItems['translationUnits'] as $transUnitId => $value) {
-			$matrix[$transUnitId]['source'] = $value[0]['source'];
-			$matrix[$transUnitId]['transUnitId'] = $transUnitId;
-
-			// check if untranslated
-			if (!isset($toItems['translationUnits'][$transUnitId][0]['target'])
-				|| $toItems['translationUnits'][$transUnitId][0]['target'] == ''
-			) {
-				$matrix[$transUnitId]['target'] = '';
-				$matrix[$transUnitId]['nonTranslated'] = TRUE;
-				$matrix[$transUnitId]['class'] = 'nonTranslated';
-			} else {
-				$matrix[$transUnitId]['target'] = $toItems['translationUnits'][$transUnitId][0]['target'];
-				// check if original text was modified
-				if ($toItems['translationUnits'][$transUnitId][0]['source'] != $value[0]['source']) {
-					$matrix[$transUnitId]['originalModified'] = TRUE;
-					$matrix[$transUnitId]['class'] = 'modified';
-					$matrix[$transUnitId]['originalSource'] = $toItems['translationUnits'][$transUnitId][0]['source'];
-				} else {
-					// translation available AND original text is still the same
-					$matrix[$transUnitId]['perfetto'] = TRUE;
-					$matrix[$transUnitId]['class'] = 'ok';
-				}
-			}
-		}
-
-		return $matrix;
-	}
-
-	/**
-	 * Reads a particular Xliff file and returns it's translation units as array entries
-	 *
-	 * @param string the package key
-	 * @param string the source name (e.g. filename)
-	 * @param \TYPO3\Flow\I18n\Locale the locale
-	 *
-	 * @return array
-	 */
-	protected function getXliffDataAsArray($packageKey, $sourceName, \TYPO3\Flow\I18n\Locale $locale) {
-		$sourcePath = \TYPO3\Flow\Utility\Files::concatenatePaths(array('resource://' . $packageKey, 'Private/Translations'));
-		list($sourcePath, $foundLocale) = $this->localizationService->getXliffFilenameAndPath($sourcePath, $sourceName, $locale);
-
-		return $this->xliffParser->getParsedData($sourcePath);
 	}
 
 	/**
@@ -136,18 +65,7 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 	 * @param array $translationUnits
 	 */
 	public function saveTranslationsAction($packageKey, $fromLang, $toLang, array $translationUnits) {
-		$originalMatrix = $this->generateTranslationMatrix($packageKey, $fromLang, $toLang);
-		$matrixToSave = array();
-
-		foreach ($translationUnits as $translationUnit => $value) {
-			if (isset($value[$toLang]) && $value[$toLang] != '') {
-				$matrixToSave[$translationUnit] = $originalMatrix[$translationUnit];
-				if (isset($matrixToSave[$translationUnit]['target'])) {
-					$matrixToSave[$translationUnit]['oldTarget'] = $matrixToSave[$translationUnit]['target'];
-				}
-				$matrixToSave[$translationUnit]['target'] = $value[$toLang];
-			}
-		}
+		$matrixToSave = $this->xliffTranslatorService->getTranslationMatrixToSave($packageKey, $fromLang, $toLang, $translationUnits);
 
 		// Create the Xliff file to be written to disk later on
 		$xliffView = new \TYPO3\Fluid\View\TemplateView();
@@ -155,22 +73,9 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 
 		$xliffView->setControllerContext($this->getControllerContext());
 		$xliffView->setTemplatePathAndFilename($path);
- 		$xliffView->assign('matrixToSave', $matrixToSave);
-
-		// backup the original file before overwriting
-		$this->backupXliffFile($packageKey, $toLang);
-
-		// check if the file exists (or create an empty file in case these are the first translations)
-		if (!is_dir(dirname($this->getFilePath($packageKey, $toLang)))) {
-			mkdir(dirname($this->getFilePath($packageKey, $toLang)));
-		}
-		if (!is_file($this->getFilePath($packageKey, $toLang))) {
-			touch($this->getFilePath($packageKey, $toLang));
-		}
-
-		// write the file
-		$outputPath = $this->getFilePath($packageKey, $toLang);
-		file_put_contents($outputPath, $xliffView->render());
+		$xliffView->assign('matrixToSave', $matrixToSave);
+		$xliffContent = $xliffView->render();
+		$this->xliffTranslatorService->saveXliffFile($packageKey, $toLang, $xliffContent);
 
 		// redirect the user back to the translation page
 		$this->addFlashMessage(
@@ -189,83 +94,6 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 				'toLang' => $toLang
 			)
 		);
-	}
-
-	/**
-	 * Gets the full filesystem path to an Xliff file of a specified language within
-	 * a specific package.
-	 *
-	 * @param string $packageKey
-	 * @param string $language
-	 * @return string
-	 */
-	protected function getFilePath($packageKey, $language) {
-		return $this->packageManager->getPackage($packageKey)->getPackagePath() . 'Resources/Private/Translations/' . $language . '/Main.xlf';
-	}
-
-	/**
-	 * Creates a backup file of the existing Xliff file before it gets overwritten
-	 * by the new data later on.
-	 *
-	 * @param string $packageKey
-	 * @param string $language
-	 */
-	protected function backupXliffFile($packageKey, $language) {
-		if (is_file($this->getFilePath($packageKey, $language))) {
-			copy(
-				$this->getFilePath($packageKey, $language),
-				$this->getFilePath($packageKey, $language) . '_backup_' . time()
-			);
-		}
-	}
-
-	/**
-	 * Returns an array of packages that are available for translation.
-	 *
-	 * The list includes basically every active package
-	 * - minus the ones that are excluded in the configuration
-	 * - minus the ones that don't have the needed translation files
-	 *
-	 * @return array all the available packages
-	 */
-	protected function getAvailablePackages() {
-		$allPackages = $this->packageManager->getActivePackages();
-
-		// make sure the packages of the framework are excluded depending on our settings
-		$packages = array();
-		$packagesToExclude = \TYPO3\Flow\Utility\Arrays::trimExplode(',', $this->settings['packagesToExclude']);
-		foreach ($allPackages as $package) {
-			if (!in_array($package->getPackageKey(), $packagesToExclude)
-				&& $this->hasXliffFilesInDefaultDirectories($package)
-			) {
-				$packages[] = $package;
-			}
-		}
-
-		return $packages;
-	}
-
-	/**
-	 * Checks if a package is qualified to be shown for translations (e.g. the default
-	 * directories and the file exists.
-	 *
-	 * The check depends on the default language from the configuration!
-	 *
-	 * @param \TYPO3\Flow\Package\Package $package
-	 * @return boolean
-	 */
-	protected function hasXliffFilesInDefaultDirectories(\TYPO3\Flow\Package\Package $package) {
-		$packageBasePath = $package->getResourcesPath();
-		$defaultLanguage = $this->settings['defaultLanguage'];
-
-		if (is_dir($packageBasePath . 'Private/Translations')
-			&& is_dir($packageBasePath . 'Private/Translations/' . $defaultLanguage)
-			&& is_file($packageBasePath . 'Private/Translations/' . $defaultLanguage . '/Main.xlf')
-		) {
-			return true;
-		}
-
-		return false;
 	}
 }
 

--- a/Classes/Mrimann/XliffTranslator/Controller/StandardController.php
+++ b/Classes/Mrimann/XliffTranslator/Controller/StandardController.php
@@ -71,7 +71,7 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 	 */
 	public function updateAction($packageKey, $editLang, array $editUnits, $sourceName = 'Main') {
 		list($sourceLang, $matrixToSave) = $this->xliffTranslatorService->getEditMatrixToSave($packageKey, $editLang, $editUnits, $sourceName);
-		$this->saveXliff($packageKey, $sourceLang, $editLang, $matrixToSave, $sourceName);
+		$this->xliffTranslatorService->saveXliff($packageKey, $sourceLang, $editLang, $matrixToSave, $this->controllerContext, $sourceName);
 
 		// redirect the user back to the edit page
 		$this->addFlashMessage(
@@ -122,7 +122,7 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 	 */
 	public function saveTranslationsAction($packageKey, $fromLang, $toLang, array $translationUnits, $sourceName = 'Main') {
 		$matrixToSave = $this->xliffTranslatorService->getTranslationMatrixToSave($packageKey, $fromLang, $toLang, $translationUnits, $sourceName);
-		$this->saveXliff($packageKey, $fromLang, $toLang, $matrixToSave, $sourceName);
+		$this->xliffTranslatorService->saveXliff($packageKey, $fromLang, $toLang, $matrixToSave, $this->getControllerContext(), $sourceName);
 
 		// redirect the user back to the translation page
 		$this->addFlashMessage(
@@ -142,29 +142,6 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 				'toLang' => $toLang
 			)
 		);
-	}
-
-	/**
-	 * @param string $packageKey
-	 * @param string $matrixToSave
-	 * @param string $sourceLang
-	 * @param string $targetLang
-	 * @param string $sourceName
-	 */
-	protected function saveXliff($packageKey, $sourceLang, $targetLang, $matrixToSave, $sourceName)
-	{
-		// Create the Xliff file to be written to disk later on
-		$xliffView = new \TYPO3\Fluid\View\TemplateView();
-		$path = 'resource://Mrimann.XliffTranslator/Private/Templates/Standard/Xliff.xlf';
-
-		$xliffView->setControllerContext($this->getControllerContext());
-		$xliffView->setTemplatePathAndFilename($path);
-
-		$xliffView->assign('sourceLang', $sourceLang);
-		$xliffView->assign('targetLang', $targetLang);
-		$xliffView->assign('matrixToSave', $matrixToSave);
-		$xliffContent = $xliffView->render();
-		$this->xliffTranslatorService->saveXliffFile($packageKey, $targetLang, $xliffContent, $sourceName);
 	}
 }
 

--- a/Classes/Mrimann/XliffTranslator/Controller/StandardController.php
+++ b/Classes/Mrimann/XliffTranslator/Controller/StandardController.php
@@ -23,7 +23,7 @@ class StandardController extends \TYPO3\Flow\Mvc\Controller\ActionController {
 
 	/**
 	 * @Flow\Inject
-	 * @var \Mrimann\XliffTranslator\XliffTranslatorService
+	 * @var \Mrimann\XliffTranslator\XliffTranslatorServiceInterface
 	 */
 	protected $xliffTranslatorService;
 

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorService.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorService.php
@@ -1,0 +1,236 @@
+<?php
+namespace Mrimann\XliffTranslator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "Mrimann.XliffTranslator".*
+ *                                                                        *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A Service which contains the main functionality of the XliffTranslator
+ *
+ * @Flow\Scope("singleton")
+ */
+class XliffTranslatorService
+{
+
+	/**
+	 * @Flow\InjectConfiguration
+	 * @var array
+	 */
+	protected $settings;
+
+	/**
+	 * @Flow\Inject
+	 * @var \TYPO3\Flow\Package\PackageManagerInterface
+	 */
+	protected $packageManager;
+
+	/**
+	 * @Flow\Inject
+	 * @var \TYPO3\Flow\I18n\Service
+	 */
+	protected $localizationService;
+
+	/**
+	 * @Flow\Inject
+	 * @var \TYPO3\Flow\I18n\Xliff\XliffParser
+	 */
+	protected $xliffParser;
+
+	/**
+	 * Returns an array of packages that are available for translation.
+	 *
+	 * The list includes basically every active package
+	 * - minus the ones that are excluded in the configuration
+	 * - minus the ones that don't have the needed translation files
+	 *
+	 * @return array all the available packages
+	 */
+	public function getAvailablePackages() {
+		$allPackages = $this->packageManager->getActivePackages();
+
+		// make sure the packages of the framework are excluded depending on our settings
+		$packages = array();
+		$packagesToExclude = \TYPO3\Flow\Utility\Arrays::trimExplode(',', $this->settings['packagesToExclude']);
+		/** @var \TYPO3\Flow\Package\Package $package */
+		foreach ($allPackages as $package) {
+			if (!in_array($package->getPackageKey(), $packagesToExclude)
+				&& $this->hasXliffFilesInDefaultDirectories($package)
+			) {
+				$packages[] = $package;
+			}
+		}
+
+		return $packages;
+	}
+
+	/**
+	 * Generates a multi-dimensional array, the matrix, containing all translations units from the
+	 * source language, combined with (where existing) the translated snippets in the target
+	 * language.
+	 *
+	 * For each translation unit, the status is stated in the matrix (new and untranslated, modified
+	 * or already translated)
+	 *
+	 * @param string $packageKey package key
+	 * @param string $fromLang source language's language key
+	 * @param string $toLang target language's language key
+	 * @return array the translation matrix
+	 */
+	public function generateTranslationMatrix($packageKey, $fromLang, $toLang) {
+		$matrix = array();
+		$fromLocale = new \TYPO3\Flow\I18n\Locale($fromLang);
+		$fromItems = $this->getXliffDataAsArray($packageKey, 'Main', $fromLocale);
+
+		$toLocale = new \TYPO3\Flow\I18n\Locale($toLang);
+		$toItems = $this->getXliffDataAsArray($packageKey, 'Main', $toLocale);
+
+		foreach ($fromItems['translationUnits'] as $transUnitId => $value) {
+			$matrix[$transUnitId]['source'] = $value[0]['source'];
+			$matrix[$transUnitId]['transUnitId'] = $transUnitId;
+
+			// check if untranslated
+			if (!isset($toItems['translationUnits'][$transUnitId][0]['target'])
+				|| $toItems['translationUnits'][$transUnitId][0]['target'] == ''
+			) {
+				$matrix[$transUnitId]['target'] = '';
+				$matrix[$transUnitId]['nonTranslated'] = TRUE;
+				$matrix[$transUnitId]['class'] = 'nonTranslated';
+			} else {
+				$matrix[$transUnitId]['target'] = $toItems['translationUnits'][$transUnitId][0]['target'];
+				// check if original text was modified
+				if ($toItems['translationUnits'][$transUnitId][0]['source'] != $value[0]['source']) {
+					$matrix[$transUnitId]['originalModified'] = TRUE;
+					$matrix[$transUnitId]['class'] = 'modified';
+					$matrix[$transUnitId]['originalSource'] = $toItems['translationUnits'][$transUnitId][0]['source'];
+				} else {
+					// translation available AND original text is still the same
+					$matrix[$transUnitId]['perfetto'] = TRUE;
+					$matrix[$transUnitId]['class'] = 'ok';
+				}
+			}
+		}
+
+		return $matrix;
+	}
+
+	/**
+	 * Returns the translations matrix to be saved
+	 *
+	 * @param string $packageKey
+	 * @param string $fromLang
+	 * @param string $toLang
+	 * @param array $translationUnits
+	 *
+	 * @return array
+	 */
+	public function getTranslationMatrixToSave($packageKey, $fromLang, $toLang, array $translationUnits) {
+		$originalMatrix = $this->generateTranslationMatrix($packageKey, $fromLang, $toLang);
+		$matrixToSave = array();
+
+		foreach ($translationUnits as $translationUnit => $value) {
+			if (isset($value[$toLang]) && $value[$toLang] != '') {
+				$matrixToSave[$translationUnit] = $originalMatrix[$translationUnit];
+				if (isset($matrixToSave[$translationUnit]['target'])) {
+					$matrixToSave[$translationUnit]['oldTarget'] = $matrixToSave[$translationUnit]['target'];
+				}
+				$matrixToSave[$translationUnit]['target'] = $value[$toLang];
+			}
+		}
+		return $matrixToSave;
+	}
+
+	/**
+	 * Saves the new Xliff file and backups the existing one
+	 *
+	 * @param string $packageKey
+	 * @param string $language
+	 * @param string $content
+	 */
+	public function saveXliffFile($packageKey, $language, $content) {
+		// backup the original file before overwriting
+		$this->backupXliffFile($packageKey, $language);
+
+		// check if the file exists (or create an empty file in case these are the first translations)
+		if (!is_dir(dirname($this->getFilePath($packageKey, $language)))) {
+			mkdir(dirname($this->getFilePath($packageKey, $language)));
+		}
+		if (!is_file($this->getFilePath($packageKey, $language))) {
+			touch($this->getFilePath($packageKey, $language));
+		}
+
+		// write the file
+		$outputPath = $this->getFilePath($packageKey, $language);
+		file_put_contents($outputPath, $content);
+	}
+
+	/**
+	 * Reads a particular Xliff file and returns it's translation units as array entries
+	 *
+	 * @param string $packageKey package key
+	 * @param string $sourceName source name (e.g. filename)
+	 * @param \TYPO3\Flow\I18n\Locale the locale
+	 *
+	 * @return array
+	 */
+	protected function getXliffDataAsArray($packageKey, $sourceName, \TYPO3\Flow\I18n\Locale $locale) {
+		$sourcePath = \TYPO3\Flow\Utility\Files::concatenatePaths(array('resource://' . $packageKey, 'Private/Translations'));
+		list($sourcePath, $foundLocale) = $this->localizationService->getXliffFilenameAndPath($sourcePath, $sourceName, $locale);
+
+		return $this->xliffParser->getParsedData($sourcePath);
+	}
+
+	/**
+	 * Checks if a package is qualified to be shown for translations (e.g. the default
+	 * directories and the file exists.
+	 *
+	 * The check depends on the default language from the configuration!
+	 *
+	 * @param \TYPO3\Flow\Package\Package $package
+	 * @return boolean
+	 */
+	protected function hasXliffFilesInDefaultDirectories(\TYPO3\Flow\Package\Package $package) {
+		$packageBasePath = $package->getResourcesPath();
+		$defaultLanguage = $this->settings['defaultLanguage'];
+
+		if (is_dir($packageBasePath . 'Private/Translations')
+			&& is_dir($packageBasePath . 'Private/Translations/' . $defaultLanguage)
+			&& is_file($packageBasePath . 'Private/Translations/' . $defaultLanguage . '/Main.xlf')
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gets the full filesystem path to an Xliff file of a specified language within
+	 * a specific package.
+	 *
+	 * @param string $packageKey
+	 * @param string $language
+	 * @return string
+	 */
+	protected function getFilePath($packageKey, $language) {
+		return $this->packageManager->getPackage($packageKey)->getPackagePath() . 'Resources/Private/Translations/' . $language . '/Main.xlf';
+	}
+
+	/**
+	 * Creates a backup file of the existing Xliff file before it gets overwritten
+	 * by the new data later on.
+	 *
+	 * @param string $packageKey
+	 * @param string $language
+	 */
+	protected function backupXliffFile($packageKey, $language) {
+		if (is_file($this->getFilePath($packageKey, $language))) {
+			copy(
+				$this->getFilePath($packageKey, $language),
+				$this->getFilePath($packageKey, $language) . '_backup_' . time()
+			);
+		}
+	}
+}

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorService.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorService.php
@@ -13,7 +13,7 @@ use TYPO3\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-class XliffTranslatorService
+class XliffTranslatorService implements XliffTranslatorServiceInterface
 {
 
 	/**

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorService.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorService.php
@@ -30,6 +30,12 @@ class XliffTranslatorService implements XliffTranslatorServiceInterface
 
 	/**
 	 * @Flow\Inject
+	 * @var \TYPO3\Flow\Cache\CacheManager
+	 */
+	protected $cacheManager;
+
+	/**
+	 * @Flow\Inject
 	 * @var \TYPO3\Flow\I18n\Service
 	 */
 	protected $localizationService;
@@ -254,6 +260,8 @@ class XliffTranslatorService implements XliffTranslatorServiceInterface
 
 		$this->backupXliffFile($packageKey, $targetLang, $sourceName);
 		$this->saveXliffFile($packageKey, $targetLang, $xliffContent, $sourceName);
+
+		$this->cacheManager->getCache('Flow_I18n_XmlModelCache')->flush();
 	}
 
 	/**

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
@@ -79,13 +79,15 @@ interface XliffTranslatorServiceInterface
 	public function getEditMatrixToSave($packageKey, $editLang, array $editUnits, $sourceName = 'Main');
 
 	/**
-	 * Saves the new Xliff file
+	 * Render and save the Xliff file
 	 *
 	 * @param string $packageKey
-	 * @param string $language
-	 * @param string $content
-	 * @param string $sourceName file name
+	 * @param string $sourceLang
+	 * @param string $targetLang
+	 * @param array $matrixToSave
+	 * @param \TYPO3\Flow\Mvc\Controller\ControllerContext $context
+	 * @param string $sourceName
 	 */
-	public function saveXliffFile($packageKey, $language, $content, $sourceName = 'Main');
+	public function saveXliff($packageKey, $sourceLang, $targetLang, array $matrixToSave, \TYPO3\Flow\Mvc\Controller\ControllerContext $context, $sourceName = 'Main');
 
 }

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
@@ -1,0 +1,56 @@
+<?php
+namespace Mrimann\XliffTranslator;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow package "Mrimann.XliffTranslator".*
+ *                                                                        *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * An interface for xliff translator services
+ */
+interface XliffTranslatorServiceInterface
+{
+    /**
+     * Returns an array of packages that are available for translation.
+     *
+     * @return array
+     */
+    public function getAvailablePackages();
+
+    /**
+     * Generates a multi-dimensional array, the matrix, containing all translations units from the
+     * source language, combined with (where existing) the translated snippets in the target
+     * language.
+     *
+     * @param string $packageKey package key
+     * @param string $fromLang source language's language key
+     * @param string $toLang target language's language key
+     * @return array the translation matrix
+     */
+    public function generateTranslationMatrix($packageKey, $fromLang, $toLang);
+
+    /**
+     * Returns the translations matrix to be saved
+     *
+     * @param string $packageKey
+     * @param string $fromLang
+     * @param string $toLang
+     * @param array $translationUnits
+     *
+     * @return array
+     */
+    public function getTranslationMatrixToSave($packageKey, $fromLang, $toLang, array $translationUnits);
+
+    /**
+     * Saves the new Xliff file
+     *
+     * @param string $packageKey
+     * @param string $language
+     * @param string $content
+     */
+    public function saveXliffFile($packageKey, $language, $content);
+
+}

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
@@ -13,55 +13,79 @@ use TYPO3\Flow\Annotations as Flow;
  */
 interface XliffTranslatorServiceInterface
 {
-    /**
-     * Returns an array of packages that are available for translation.
-     *
-     * @return array
-     */
-    public function getAvailablePackages();
+	/**
+	 * Returns an array of packages that are available for translation.
+	 *
+	 * @return array
+	 */
+	public function getAvailablePackages();
 
-    /**
-     * Returns an array of files that are available for translation.
-     *
-     * @param string $packageKey package key
-     * @return array
-     */
-    public function getAvailableXliffFiles($packageKey);
+	/**
+	 * Returns an array of files that are available for translation.
+	 *
+	 * @param string $packageKey package key
+	 * @return array
+	 */
+	public function getAvailableXliffFiles($packageKey);
 
-    /**
-     * Generates a multi-dimensional array, the matrix, containing all translations units from the
-     * source language, combined with (where existing) the translated snippets in the target
-     * language.
-     *
-     * @param string $packageKey package key
-     * @param string $fromLang source language's language key
-     * @param string $toLang target language's language key
-     * @param string $sourceName file name
-     * @return array the translation matrix
-     */
-    public function generateTranslationMatrix($packageKey, $fromLang, $toLang, $sourceName = 'Main');
+	/**
+	 * Generates a multi-dimensional array, the matrix, containing all translations units from the
+	 * source language, combined with (where existing) the translated snippets in the target
+	 * language.
+	 *
+	 * @param string $packageKey package key
+	 * @param string $fromLang source language's language key
+	 * @param string $toLang target language's language key
+	 * @param string $sourceName file name
+	 * @return array the translation matrix
+	 */
+	public function generateTranslationMatrix($packageKey, $fromLang, $toLang, $sourceName = 'Main');
 
-    /**
-     * Returns the translations matrix to be saved
-     *
-     * @param string $packageKey
-     * @param string $fromLang
-     * @param string $toLang
-     * @param array $translationUnits
-     * @param string $sourceName file name
-     *
-     * @return array
-     */
-    public function getTranslationMatrixToSave($packageKey, $fromLang, $toLang, array $translationUnits, $sourceName = 'Main');
+	/**
+	 * Returns the translations matrix to be saved
+	 *
+	 * @param string $packageKey
+	 * @param string $fromLang
+	 * @param string $toLang
+	 * @param array $translationUnits
+	 * @param string $sourceName file name
+	 *
+	 * @return array
+	 */
+	public function getTranslationMatrixToSave($packageKey, $fromLang, $toLang, array $translationUnits, $sourceName = 'Main');
 
-    /**
-     * Saves the new Xliff file
-     *
-     * @param string $packageKey
-     * @param string $language
-     * @param string $content
-     * @param string $sourceName file name
-     */
-    public function saveXliffFile($packageKey, $language, $content, $sourceName = 'Main');
+
+	/**
+	 * Generates a multi-dimensional array, the matrix, containing all translations units to edit. This are either the
+	 * target or the source tags, depending wherever the xlf file contains a translation or not.
+	 *
+	 * @param string $packageKey package key
+	 * @param string $editLang source language's language key
+	 * @param string $sourceName name of the xlf source file
+	 * @return array
+	 */
+	public function generateEditMatrix($packageKey, $editLang, $sourceName = 'Main');
+
+	/**
+	 * Returns the matrix to be saved
+	 *
+	 * @param string $packageKey
+	 * @param string $editLang
+	 * @param array $editUnits
+	 * @param string $sourceName
+	 *
+	 * @return array
+	 */
+	public function getEditMatrixToSave($packageKey, $editLang, array $editUnits, $sourceName = 'Main');
+
+	/**
+	 * Saves the new Xliff file
+	 *
+	 * @param string $packageKey
+	 * @param string $language
+	 * @param string $content
+	 * @param string $sourceName file name
+	 */
+	public function saveXliffFile($packageKey, $language, $content, $sourceName = 'Main');
 
 }

--- a/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
+++ b/Classes/Mrimann/XliffTranslator/XliffTranslatorServiceInterface.php
@@ -21,6 +21,14 @@ interface XliffTranslatorServiceInterface
     public function getAvailablePackages();
 
     /**
+     * Returns an array of files that are available for translation.
+     *
+     * @param string $packageKey package key
+     * @return array
+     */
+    public function getAvailableXliffFiles($packageKey);
+
+    /**
      * Generates a multi-dimensional array, the matrix, containing all translations units from the
      * source language, combined with (where existing) the translated snippets in the target
      * language.
@@ -28,9 +36,10 @@ interface XliffTranslatorServiceInterface
      * @param string $packageKey package key
      * @param string $fromLang source language's language key
      * @param string $toLang target language's language key
+     * @param string $sourceName file name
      * @return array the translation matrix
      */
-    public function generateTranslationMatrix($packageKey, $fromLang, $toLang);
+    public function generateTranslationMatrix($packageKey, $fromLang, $toLang, $sourceName = 'Main');
 
     /**
      * Returns the translations matrix to be saved
@@ -39,10 +48,11 @@ interface XliffTranslatorServiceInterface
      * @param string $fromLang
      * @param string $toLang
      * @param array $translationUnits
+     * @param string $sourceName file name
      *
      * @return array
      */
-    public function getTranslationMatrixToSave($packageKey, $fromLang, $toLang, array $translationUnits);
+    public function getTranslationMatrixToSave($packageKey, $fromLang, $toLang, array $translationUnits, $sourceName = 'Main');
 
     /**
      * Saves the new Xliff file
@@ -50,7 +60,8 @@ interface XliffTranslatorServiceInterface
      * @param string $packageKey
      * @param string $language
      * @param string $content
+     * @param string $sourceName file name
      */
-    public function saveXliffFile($packageKey, $language, $content);
+    public function saveXliffFile($packageKey, $language, $content, $sourceName = 'Main');
 
 }

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -6,7 +6,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title><f:render section="Title" /></title>
-		<bootstrap:include version="2.1" />
+		<f:format.raw><bootstrap:include version="2.1" /></f:format.raw>
 		<link href="{f:uri.resource(path: 'Css/xliffTranslator.css')}" media="screen" rel="stylesheet" type="text/css" />
 		<f:base />
 	</head>

--- a/Resources/Private/Partials/EditUnit.html
+++ b/Resources/Private/Partials/EditUnit.html
@@ -2,10 +2,10 @@
 	<div class="span11">
 		<f:if condition="{sourceLang} != {editLang}">
 			<f:then>
-				<f:form.textfield name="editUnits[{editUnit.transUnitId}][{editLang}]" value="{editUnit.target}" class="input-xxxlarge" />
+				<f:form.textarea name="editUnits[{editUnit.transUnitId}][{editLang}]" value="{editUnit.target}" class="input-xxxlarge" />
 			</f:then>
 			<f:else>
-				<f:form.textfield name="editUnits[{editUnit.transUnitId}][{editLang}]" value="{editUnit.source}" class="input-xxxlarge" />
+				<f:form.textarea name="editUnits[{editUnit.transUnitId}][{editLang}]" value="{editUnit.source}" class="input-xxxlarge" />
 			</f:else>
 		</f:if>
 	</div>

--- a/Resources/Private/Partials/EditUnit.html
+++ b/Resources/Private/Partials/EditUnit.html
@@ -1,0 +1,12 @@
+<div class="row translationUnit editUnit">
+	<div class="span11">
+		<f:if condition="{sourceLang} != {editLang}">
+			<f:then>
+				<f:form.textfield name="editUnits[{editUnit.transUnitId}][{editLang}]" value="{editUnit.target}" class="input-xxxlarge" />
+			</f:then>
+			<f:else>
+				<f:form.textfield name="editUnits[{editUnit.transUnitId}][{editLang}]" value="{editUnit.source}" class="input-xxxlarge" />
+			</f:else>
+		</f:if>
+	</div>
+</div>

--- a/Resources/Private/Partials/TranslationUnit.html
+++ b/Resources/Private/Partials/TranslationUnit.html
@@ -21,6 +21,6 @@
 	</div>
 	<div class="span7">
 		To:<br />
-		<f:form.textfield name="translationUnits[{translationUnit.transUnitId}][{toLang}]" value="{translationUnit.target}" class="input-xxlarge" />
+		<f:form.textarea name="translationUnits[{translationUnit.transUnitId}][{toLang}]" value="{translationUnit.target}" class="input-xxlarge" />
 	</div>
 </div>

--- a/Resources/Private/Templates/Standard/Edit.html
+++ b/Resources/Private/Templates/Standard/Edit.html
@@ -1,0 +1,27 @@
+{namespace xliffTranslator=Mrimann\XliffTranslator\ViewHelpers}
+
+<f:layout name="Default" />
+
+<f:section name="Title">Let's translate {packageKey}</f:section>
+
+<f:section name="Content">
+	<p>PackageKey: <b>{packageKey}</b></p>
+	<p>Editing <b>{sourceName}</b> in <b>{editLang}</b>.</p>
+
+	<div class="row">
+		<xliffTranslator:flashMessages />
+	</div>
+
+	<f:if condition="{editMatrix}">
+		<f:form action="update" arguments="{packageKey: packageKey, sourceName: sourceName, editLang: editLang}" >
+			<f:for each="{editMatrix}" as="editUnit">
+				<f:render partial="EditUnit" arguments="{editUnit: editUnit, editLang: editLang, sourceLang: sourceLang}" />
+			</f:for>
+			<div class="row">
+				<div class="span2 offset9">
+					<f:form.submit class="btn btn-primary" value="Save Sources" />
+				</div>
+			</div>
+		</f:form>
+	</f:if>
+</f:section>

--- a/Resources/Private/Templates/Standard/Index.html
+++ b/Resources/Private/Templates/Standard/Index.html
@@ -8,7 +8,7 @@
 
 		<f:for each="{packages}" as="package">
 			<li>
-				<f:link.action action="translate" arguments="{packageKey: package.packageKey}">
+				<f:link.action action="package" arguments="{packageKey: package.packageKey}">
 					{package.packageKey}
 				</f:link.action>
 			</li>

--- a/Resources/Private/Templates/Standard/Package.html
+++ b/Resources/Private/Templates/Standard/Package.html
@@ -1,0 +1,34 @@
+{namespace xliffTranslator=Mrimann\XliffTranslator\ViewHelpers}
+
+<f:layout name="Default" />
+
+<f:section name="Title">Let's translate {packageKey}</f:section>
+
+<f:section name="Content">
+	<p>PackageKey: <b>{packageKey}</b></p>
+
+	<div class="row">
+		<xliffTranslator:flashMessages />
+	</div>
+
+	<f:for each="{sourceNames}" as="source">
+		<f:for each="{languages}" as="editLang">
+			<li>
+				<f:link.action action="edit" arguments="{packageKey: packageKey, sourceName: source, editLang: editLang}">
+					Edit "{source}" in "{editLang}"
+				</f:link.action>
+			</li>
+		</f:for>
+		<f:for each="{languages}" as="fromLanguage">
+			<f:for each="{languages}" as="toLanguage">
+				<f:if condition="{0: toLanguage} != {0: fromLanguage}">
+					<li>
+						<f:link.action action="translate" arguments="{packageKey: packageKey, sourceName: source, fromLang: fromLanguage, toLang: toLanguage}">
+							Translate "{source}" from "{fromLanguage}" to "{toLanguage}"
+						</f:link.action>
+					</li>
+				</f:if>
+			</f:for>
+		</f:for>
+	</f:for>
+</f:section>

--- a/Resources/Private/Templates/Standard/Translate.html
+++ b/Resources/Private/Templates/Standard/Translate.html
@@ -6,48 +6,22 @@
 
 <f:section name="Content">
 	<p>PackageKey: <b>{packageKey}</b></p>
-	<f:if condition="{readyForTranslating}">
-		<p>Translating <b>{sourceName}</b> from <b>{fromLang}</b> to <b>{toLang}</b>.</p>
-	</f:if>
+	<p>Translating <b>{sourceName}</b> from <b>{fromLang}</b> to <b>{toLang}</b>.</p>
 
 	<div class="row">
 		<xliffTranslator:flashMessages />
 	</div>
 
-	<f:if condition="{readyForTranslating}">
-		<f:then>
-			<f:if condition="{translationMatrix}">
-				<f:form action="saveTranslations" arguments="{packageKey: packageKey, sourceName: sourceName, fromLang: fromLang, toLang: toLang}" >
-					<f:for each="{translationMatrix}" as="translationUnit">
-						<f:render partial="TranslationUnit" arguments="{translationUnit: translationUnit, toLang: toLang}" />
-					</f:for>
-					<div class="row">
-						<div class="span2 offset9">
-							<f:form.submit class="btn btn-primary" value="Save Translations" />
-						</div>
-					</div>
-				</f:form>
-			</f:if>
-		</f:then>
-		<f:else>
-			<f:for each="{sourceNames}" as="source">
-				<f:for each="{languages}" as="fromLanguage">
-					<f:for each="{languages}" as="toLanguage">
-						<f:if condition="{0: toLanguage} == {0: fromLanguage}">
-							<f:then>
-
-							</f:then>
-							<f:else>
-								<li>
-									<f:link.action action="translate" arguments="{packageKey: packageKey, sourceName: source, fromLang: fromLanguage, toLang: toLanguage}">
-										{packageKey} "{source}" from "{fromLanguage}" to "{toLanguage}"
-									</f:link.action>
-								</li>
-							</f:else>
-						</f:if>
-					</f:for>
-				</f:for>
+	<f:if condition="{translationMatrix}">
+		<f:form action="saveTranslations" arguments="{packageKey: packageKey, sourceName: sourceName, fromLang: fromLang, toLang: toLang}" >
+			<f:for each="{translationMatrix}" as="translationUnit">
+				<f:render partial="TranslationUnit" arguments="{translationUnit: translationUnit, toLang: toLang}" />
 			</f:for>
-		</f:else>
+			<div class="row">
+				<div class="span2 offset9">
+					<f:form.submit class="btn btn-primary" value="Save Translations" />
+				</div>
+			</div>
+		</f:form>
 	</f:if>
 </f:section>

--- a/Resources/Private/Templates/Standard/Translate.html
+++ b/Resources/Private/Templates/Standard/Translate.html
@@ -6,7 +6,9 @@
 
 <f:section name="Content">
 	<p>PackageKey: <b>{packageKey}</b></p>
-	<p>Translating from <b>{fromLang}</b> to <b>{toLang}</b>.</p>
+	<f:if condition="{readyForTranslating}">
+		<p>Translating <b>{sourceName}</b> from <b>{fromLang}</b> to <b>{toLang}</b>.</p>
+	</f:if>
 
 	<div class="row">
 		<xliffTranslator:flashMessages />
@@ -15,7 +17,7 @@
 	<f:if condition="{readyForTranslating}">
 		<f:then>
 			<f:if condition="{translationMatrix}">
-				<f:form action="saveTranslations" arguments="{packageKey: packageKey, fromLang: fromLang, toLang: toLang}" >
+				<f:form action="saveTranslations" arguments="{packageKey: packageKey, sourceName: sourceName, fromLang: fromLang, toLang: toLang}" >
 					<f:for each="{translationMatrix}" as="translationUnit">
 						<f:render partial="TranslationUnit" arguments="{translationUnit: translationUnit, toLang: toLang}" />
 					</f:for>
@@ -28,20 +30,22 @@
 			</f:if>
 		</f:then>
 		<f:else>
-			<f:for each="{languages}" as="fromLanguage">
-				<f:for each="{languages}" as="toLanguage">
-					<f:if condition="{0: toLanguage} == {0: fromLanguage}">
-						<f:then>
+			<f:for each="{sourceNames}" as="source">
+				<f:for each="{languages}" as="fromLanguage">
+					<f:for each="{languages}" as="toLanguage">
+						<f:if condition="{0: toLanguage} == {0: fromLanguage}">
+							<f:then>
 
-						</f:then>
-						<f:else>
-							<li>
-								<f:link.action action="translate" arguments="{packageKey: packageKey, fromLang: fromLanguage, toLang: toLanguage}">
-									{packageKey} from "{fromLanguage}" to "{toLanguage}"
-								</f:link.action>
-							</li>
-						</f:else>
-					</f:if>
+							</f:then>
+							<f:else>
+								<li>
+									<f:link.action action="translate" arguments="{packageKey: packageKey, sourceName: source, fromLang: fromLanguage, toLang: toLanguage}">
+										{packageKey} "{source}" from "{fromLanguage}" to "{toLanguage}"
+									</f:link.action>
+								</li>
+							</f:else>
+						</f:if>
+					</f:for>
 				</f:for>
 			</f:for>
 		</f:else>

--- a/Resources/Private/Templates/Standard/Xliff.xlf
+++ b/Resources/Private/Templates/Standard/Xliff.xlf
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" source-language="en" target-language="en" datatype="plaintext">
+	<file original="" source-language="{sourceLang}" {f:if(condition: '{sourceLang} != {targetLang}', then: 'target-language="{targetLang}"')} datatype="plaintext">
 		<body><f:for each="{matrixToSave}" as="translationUnit">
 			<trans-unit id="{translationUnit.transUnitId}">
-				<source>{translationUnit.source}</source>
-				<target>{translationUnit.target}</target>
+				<source>{translationUnit.source}</source><f:if condition="{sourceLang} != {targetLang}">
+				<target>{translationUnit.target}</target></f:if>
 			</trans-unit></f:for>
 		</body>
 	</file>

--- a/Resources/Private/Templates/Standard/Xliff.xlf
+++ b/Resources/Private/Templates/Standard/Xliff.xlf
@@ -3,8 +3,8 @@
 	<file original="" source-language="{sourceLang}" {f:if(condition: '{sourceLang} != {targetLang}', then: 'target-language="{targetLang}"')} datatype="plaintext">
 		<body><f:for each="{matrixToSave}" as="translationUnit">
 			<trans-unit id="{translationUnit.transUnitId}">
-				<source>{translationUnit.source}</source><f:if condition="{sourceLang} != {targetLang}">
-				<target>{translationUnit.target}</target></f:if>
+				<source><f:format.raw>{translationUnit.source}</f:format.raw></source><f:if condition="{sourceLang} != {targetLang}">
+				<target><f:format.raw>{translationUnit.target}</f:format.raw></target></f:if>
 			</trans-unit></f:for>
 		</body>
 	</file>

--- a/Resources/Public/Css/xliffTranslator.css
+++ b/Resources/Public/Css/xliffTranslator.css
@@ -26,8 +26,18 @@
     width: 510px;
 }
 
+.input-xxxlarge {
+    width: 820px;
+}
+
 span.label {
     position: absolute;
     top: 3px;
     left: -84px;
+}
+
+.row.editUnit {
+    border-left: 5px solid darkgrey;
+    border-right: 5px solid darkgrey;
+    background-color: lightgrey;
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"typo3/flow": "*",
+		"typo3/flow": "~3.0",
 		"typo3/twitter-bootstrap": "*"
 	},
 	"autoload": {


### PR DESCRIPTION
Hi @mrimann, I did several enhancements on your package as I will use it for the base functionality of another package that overrides the Xliff files to a separate directory instead of physically overwriting it. (The package is not yet published.)
Besides the added features, this PR contains several changes also on the structure (XliffTranslationService) to connect it with my new package. Also I had to fix some logic on how the files are loaded and saved, so that it supports untranslated files with only target tags.
Let me know if you intend to merge it, or if you have some comments or improvements. I'm happy to adjust it.
I also put it to WIP for the moment, since possibly some adjustments will follow. Anyway, please have a look and let me know your thoughts.